### PR TITLE
Allow empty contribution from shells at z >= z_source, and add logging

### DIFF
--- a/dorian/lensing.py
+++ b/dorian/lensing.py
@@ -2,6 +2,7 @@ import numpy as np
 import healpy as hp
 from .cosmology import d_c
 from .raytracing import raytrace
+from .logging import info, success, warning
 
 
 def prepare_density_shells(
@@ -106,15 +107,21 @@ def prepare_density_shells(
     particle_mass_msun = (rho_matter * volume_box_mpc) / n_particles
     particle_mass_dorian = (particle_mass_msun * h) / 1e10
 
+    info(f"Preparing {len(density_maps)} density shells: nside={nside}, "
+         f"particle mass={particle_mass_dorian:.4e} [10^10 M_sun/h]")
+
     shells = []
     shell_distances = []
     shell_redshifts = []
 
     for i, (density_map, z) in enumerate(zip(density_maps, redshifts)):
-        if hp.npix2nside(len(density_map)) != nside:
+        map_nside = hp.npix2nside(len(density_map))
+        if map_nside != nside:
+            warning(f"Shell {i}: ud_grading nside {map_nside} -> {nside}")
             density_map = hp.ud_grade(density_map, nside, power=-2)
 
         d_k = d_c(z=z, Omega_M=omega_m, Omega_L=omega_l)
+        info(f"  Shell {i+1}/{len(density_maps)}: z={z:.4f}, d={d_k:.1f} Mpc/h")
 
         dr = shell_widths[i]
         R_min = max(d_k - dr / 2, 0.0)
@@ -126,6 +133,8 @@ def prepare_density_shells(
         shells.append(np.asarray(mass_per_pixel, dtype=np.float64))
         shell_distances.append(float(d_k))
         shell_redshifts.append(float(z))
+
+    success(f"Prepared {len(shells)} density shells")
 
     return shells, shell_distances, shell_redshifts
 
@@ -273,6 +282,9 @@ def raytrace_from_density(
     if omega_l is None:
         omega_l = 1.0 - omega_m
 
+    info(f"raytrace_from_density: z_source={z_source}, interp='{interp}', "
+         f"nside={nside if nside else 'auto'}")
+
     shells, distances, redshifts_clean = prepare_density_shells(
         density_maps=density_maps,
         redshifts=redshifts,
@@ -305,6 +317,8 @@ def raytrace_from_density(
     kappa_raytraced = 1.0 - 0.5 * (A_final[0, 0] + A_final[1, 1])
 
     n_used = sum(1 for z in redshifts_clean if z < z_source)
+
+    success(f"raytrace_from_density complete: {n_used}/{len(redshifts_clean)} shells used")
 
     return {
         'convergence_born': kappa_born,

--- a/dorian/logging.py
+++ b/dorian/logging.py
@@ -1,0 +1,66 @@
+import sys
+
+
+class Colors:
+    """ANSI color codes for terminal output, with TTY detection."""
+
+    BLUE = "\033[94m"
+    GREEN = "\033[92m"
+    YELLOW = "\033[93m"
+    RED = "\033[91m"
+    DIM = "\033[2m"
+    BOLD = "\033[1m"
+    RESET = "\033[0m"
+
+    _enabled = True
+
+    @classmethod
+    def _check_tty(cls):
+        if not sys.stdout.isatty():
+            cls.disable()
+
+    @classmethod
+    def disable(cls):
+        cls._enabled = False
+        cls.BLUE = ""
+        cls.GREEN = ""
+        cls.YELLOW = ""
+        cls.RED = ""
+        cls.DIM = ""
+        cls.BOLD = ""
+        cls.RESET = ""
+
+
+Colors._check_tty()
+
+
+def info(message):
+    """Print an info message with blue [INFO] prefix."""
+    print(f"{Colors.BLUE}[INFO]{Colors.RESET} {message}")
+
+
+def success(message):
+    """Print a success message with green checkmark."""
+    print(f"{Colors.GREEN}\u2714{Colors.RESET} {message}")
+
+
+def warning(message):
+    """Print a warning message with yellow [WARNING] prefix."""
+    print(f"{Colors.YELLOW}[WARNING]{Colors.RESET} {message}")
+
+
+def error(message):
+    """Print an error message with red [ERROR] prefix to stderr."""
+    print(f"{Colors.RED}[ERROR]{Colors.RESET} {message}", file=sys.stderr)
+
+
+def debug(message):
+    """Print a debug message with dim [DEBUG] prefix and separator lines."""
+    sep = Colors.DIM + "-" * 40 + Colors.RESET
+    print(f"{sep}\n{Colors.DIM}[DEBUG]{Colors.RESET} {message}\n{sep}")
+
+
+def banner(message):
+    """Print a separator banner."""
+    line = "=" * 60
+    print(f"{Colors.BOLD}{line}\n  {message}\n{line}{Colors.RESET}")

--- a/dorian/raytracing.py
+++ b/dorian/raytracing.py
@@ -2,6 +2,7 @@ from .constants import M_sun_cgs, Mpc2cm, c_cgs, G_cgs
 from .cosmology import d_c
 from .parallel_transport import get_rotation_angle_array, rotate_tensor_array
 from .misc import print_logo
+from .logging import info, success, warning
 import numpy as np
 import healpy as hp
 from ducc0.sht import synthesis_general
@@ -138,9 +139,28 @@ def raytrace(
                 'index': i
             })
 
+    n_contrib = len(contributing_shells)
+    info(f"Ray-tracing: nside={nside}, z_source={z_s}, interp='{interp}', "
+         f"{n_contrib}/{len(shells)} shells contributing")
 
-    if len(contributing_shells) == 0:
-        raise ValueError(f"No shells found with z < z_s ({z_s}). Check your shell redshifts.")
+    if n_contrib == 0:
+        warning(f"No shells contribute (all z >= z_source={z_s})")
+        theta = np.array(hp.pix2ang(nside, np.arange(npix)))
+        nrays = theta.shape[1]
+        
+        # kappa_born is correctly zero (no matter, no convergence)
+        kappa_born = np.zeros(nrays)
+        
+        # beta (final positions) equals initial theta
+        beta_final = theta.copy()
+        
+        # A (distortion matrix) must be the IDENTITY matrix, not zeros
+        # A_final shape is (2, 2, npix)
+        A_final = np.zeros((2, 2, nrays))
+        A_final[0, 0, :] = 1.0
+        A_final[1, 1, :] = 1.0
+        
+        return kappa_born, A_final, beta_final, theta
 
     npix = hp.nside2npix(nside)
 
@@ -170,6 +190,7 @@ def raytrace(
         z_k = shell_info['redshift']
         d_k = shell_info['distance']
         shell_data = shell_info['shell_data']
+        info(f"Shell {k+1}/{n_contrib}: z={z_k:.4f}, d={d_k:.1f} Mpc/h")
 
         Sigma = shell_data / (4 * np.pi / npix)
         Sigma_mean = np.mean(Sigma)
@@ -178,11 +199,11 @@ def raytrace(
 
         kappa_lm = hp.map2alm(kappa, pol=False, lmax=lmax)
         alpha_factor = (np.sqrt((ell * (ell + 1)))) # Must safe divide
-        alpha_factor = np.where(alpha_factor == 0, 0, - 2 / alpha_factor) # Avoid division by zero at ell=0
-        alpha_lm = hp.almxfl(kappa_lm, alpha_factor)
+        alpha_factor = np.where(alpha_factor == 0, 1.0, alpha_factor) # Avoid division by zero at ell=0
+        alpha_lm = hp.almxfl(kappa_lm, -2 / alpha_factor)
         fl_factor = (ell * (ell + 1.0))
-        fl_factor = np.where(fl_factor == 0, 0, 1 / fl_factor) # Avoid division by zero at ell=0
-        f_l = -np.sqrt((ell + 2.0) * (ell - 1.0) * fl_factor) # Must safe divide
+        fl_factor = np.where(fl_factor == 0, 1.0, fl_factor) # Avoid division by zero at ell=0
+        f_l = -np.sqrt((ell + 2.0) * (ell - 1.0) / fl_factor) # Must safe divide
         g_lm_E = hp.almxfl(kappa_lm, f_l)
 
         if interp in ["ngp", "bilinear"]:
@@ -253,7 +274,13 @@ def raytrace(
             A[1, :, :, :] = rotate_tensor_array(A[1, :, :, :], cospsi, sinpsi)
 
         kappa_born += ((d_s - d_k) / d_s) * kappa
-        
+
+        t1 = time.time()
+        info(f"  Shell {k+1}/{n_contrib} done in {t1 - t0:.2f}s")
+
+    t_end = time.time()
+    success(f"Ray-tracing complete: {n_contrib} shells in {t_end - t_begin:.2f}s")
+
     return kappa_born, A[1], beta[1], theta
 
 


### PR DESCRIPTION
This pull request introduces a new logging utility with colored terminal output and integrates it throughout the lensing and raytracing code. The main focus is on improving the clarity and user feedback of the computational process by providing informative, success, and warning messages at key stages. Additionally, minor bug fixes and code improvements are included in the raytracing logic.

**Logging and User Feedback Improvements:**

* Added a new `logging.py` module that provides colored logging functions (`info`, `success`, `warning`, `error`, `debug`, `banner`) with TTY detection for enhanced terminal output.
* Integrated the new logging functions into `lensing.py` and `raytracing.py`, adding informative messages for shell preparation, raytracing progress, and completion, as well as warnings for potential user misconfigurations (e.g., no contributing shells). [[1]](diffhunk://#diff-075698df19e3e79af66240c85db68e69d7695a2983fa381f730c9b066d2e9161R5) [[2]](diffhunk://#diff-075698df19e3e79af66240c85db68e69d7695a2983fa381f730c9b066d2e9161R110-R124) [[3]](diffhunk://#diff-075698df19e3e79af66240c85db68e69d7695a2983fa381f730c9b066d2e9161R137-R138) [[4]](diffhunk://#diff-075698df19e3e79af66240c85db68e69d7695a2983fa381f730c9b066d2e9161R285-R287) [[5]](diffhunk://#diff-075698df19e3e79af66240c85db68e69d7695a2983fa381f730c9b066d2e9161R321-R322) [[6]](diffhunk://#diff-e5015e8329cef85f2918fe4d25272cfdf63e2d29dd8dd545484bc74cf26e340dR5) [[7]](diffhunk://#diff-e5015e8329cef85f2918fe4d25272cfdf63e2d29dd8dd545484bc74cf26e340dR142-R163) [[8]](diffhunk://#diff-e5015e8329cef85f2918fe4d25272cfdf63e2d29dd8dd545484bc74cf26e340dR193) [[9]](diffhunk://#diff-e5015e8329cef85f2918fe4d25272cfdf63e2d29dd8dd545484bc74cf26e340dR278-R283)

**Bug Fixes and Numerical Stability:**

* Fixed the handling of the case when no shells contribute to raytracing by returning physically correct zero convergence, identity distortion matrix, and copying initial positions, with a warning message.
* Improved numerical stability in spherical harmonic coefficient calculations by safely handling division by zero at `ell=0`.